### PR TITLE
Add handling for RouteViews files.

### DIFF
--- a/cmd/archive_upload_server/Dockerfile
+++ b/cmd/archive_upload_server/Dockerfile
@@ -1,19 +1,26 @@
-# Should be run from the parent directory, e.g. docker build -f cmd/archive_upload_server/Dockerfile . -t [IMAGE_URL]
+# Should be run from the parent directory:
+#   docker build -f cmd/archive_upload_server/Dockerfile . -t rv-server
 FROM golang:1.17-buster as builder
- 
+
+# Set a working directory to hold built binaries.
 WORKDIR /app
- 
+
 COPY . ./
 
-RUN go mod download
- 
-RUN go build -v -o converter cmd/archive_upload_server/server.go
- 
+# Download all required golang modules.
+RUN go mod download ...
+
+# Build the server binary.
+RUN go build -v -o server cmd/archive_upload_server/server.go
+
+# Declare the base image, and update it.
 FROM debian:buster-slim
+
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy the built binary into the docker image.
 COPY --from=builder /app/server /app/server
 
 CMD ["/app/server"]

--- a/cmd/archive_upload_server/Dockerfile
+++ b/cmd/archive_upload_server/Dockerfile
@@ -1,0 +1,19 @@
+# Should be run from the parent directory, e.g. docker build -f cmd/archive_upload_server/Dockerfile . -t [IMAGE_URL]
+FROM golang:1.17-buster as builder
+ 
+WORKDIR /app
+ 
+COPY . ./
+
+RUN go mod download
+ 
+RUN go build -v -o converter cmd/archive_upload_server/server.go
+ 
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/server /app/server
+
+CMD ["/app/server"]

--- a/cmd/archive_upload_server/README.md
+++ b/cmd/archive_upload_server/README.md
@@ -1,0 +1,20 @@
+# RouteViews Archive Server
+
+Collects files to archive from remote service owners.
+
+## Deployment
+
+Deployed to GCP CloudRun, from the project's Docker image store.
+
+1. Build a current image from repository root:
+  ```shell
+  $ docker build -f cmd/archive_upload_server/Dockerfile . \
+                 --target rv-server
+  ```
+
+2. Push the docker image to the registry:
+  ```shell
+  $ docker push rv-server
+  ```
+
+3. Verify the loadbalanced path is in place from internet -> port.

--- a/cmd/archive_upload_server/README.md
+++ b/cmd/archive_upload_server/README.md
@@ -9,12 +9,17 @@ Deployed to GCP CloudRun, from the project's Docker image store.
 1. Build a current image from repository root:
   ```shell
   $ docker build -f cmd/archive_upload_server/Dockerfile . \
-                 --target rv-server
+                 --tag us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest
   ```
 
 2. Push the docker image to the registry:
   ```shell
-  $ docker push rv-server
+  $ docker push us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest
   ```
 
-3. Verify the loadbalanced path is in place from internet -> port.
+3. Have cloud run, run the job:
+  ```shell
+  $ gcloud run deploy  rv-server --image us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest
+  ```
+
+4. Verify the loadbalanced path is in place from internet -> port.

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -16,10 +16,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net"
+	"os"
 
 	"cloud.google.com/go/storage"
+	log "github.com/golang/glog"
 	pb "github.com/routeviews/google-cloud-storage/proto/rv"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -33,7 +34,7 @@ const (
 )
 
 var (
-	port   = flag.Int("port", 9876, "Port on which gRPC connections will come.")
+	port   = os.Getenv("PORT")
 	bucket = flag.String("bucket", "routeviews-archive", "Cloud storage bucket name.")
 
 	// TODO(morrowc): find a method to define the TLS certificate to be used, if this will
@@ -119,9 +120,13 @@ func (r rvServer) FileUpload(ctx context.Context, req *pb.FileRequest) (*pb.File
 func main() {
 	flag.Parse()
 
+	if port == "" {
+		port = "9876"
+		log.Infof("Default port selected: %s", port)
+	}
 	// Start the listener.
 	// NOTE: this listens on all IP Addresses, caution when testing.
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		log.Fatalf("failed to listen(): %v", err)
 	}

--- a/cmd/archive_upload_server/server_test.go
+++ b/cmd/archive_upload_server/server_test.go
@@ -43,6 +43,20 @@ func TestFileUpload(t *testing.T) {
 			Status:       pb.FileResponse_SUCCESS,
 			ErrorMessage: "",
 		},
+	}, {
+		desc:   "Routeviews: Success",
+		bucket: "foo",
+		req: &pb.FileRequest{
+			Filename:   "bar",
+			Md5Sum:     "50e3903156f5d2dac6c9f89626d48c75",
+			Content:    []byte("Foo Bar Baz"),
+			ConvertSql: false,
+			Project:    pb.FileRequest_ROUTEVIEWS,
+		},
+		want: &pb.FileResponse{
+			Status:       pb.FileResponse_SUCCESS,
+			ErrorMessage: "",
+		},
 	}}
 
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.18.2
 	github.com/dsnet/compress v0.0.1
 	github.com/fsouza/fake-gcs-server v1.31.1
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-cmp v0.5.6
 	github.com/osrg/gobgp v2.0.0+incompatible
 	github.com/routeviews/google-cloud-storage/proto/rv v0.0.0-00010101000000-000000000000
@@ -13,6 +14,7 @@ require (
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/grpc v1.40.1
+	google.golang.org/protobuf v1.27.1
 )
 
 replace github.com/routeviews/google-cloud-storage/proto/rv => ./proto

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
Also, set the bucket default name properly.
In the end a RARC file (expected JSON VRPs) and RouteViews file(s)
are handled the same way, so change a method name to be more generic.