### PR TITLE
Fix Go gRPC client

### DIFF
--- a/cmd/archive_upload_client/client.go
+++ b/cmd/archive_upload_client/client.go
@@ -1,20 +1,88 @@
-// Package main implements a golang client to speak to the RV cloud storage relay server.
+// Package main implements a golang client to upload RV archive to a Cloud Run RV service.
 package main
 
 import (
 	"context"
+	"crypto/md5"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/api/idtoken"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	pb "github.com/routeviews/google-cloud-storage/proto/rv"
-	"google.golang.org/grpc"
+	grpcMetadata "google.golang.org/grpc/metadata"
 )
 
 var (
 	server = flag.String("server", "localhost:9876", "The host:port of the gRPC server.")
-	file   = flag.String("file", "", "A File to transfer to cloud storage.")
+	file   = flag.String("file", "", "A local File to transfer to cloud storage.")
 )
+
+func newConn(host string) (*grpc.ClientConn, error) {
+	var opts []grpc.DialOption
+	opts = append(opts, grpc.WithAuthority(host))
+
+	systemRoots, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+	cred := credentials.NewTLS(&tls.Config{
+		RootCAs: systemRoots,
+	})
+	opts = append(opts, grpc.WithTransportCredentials(cred))
+
+	return grpc.Dial(host, opts...)
+}
+
+func upload(ctx context.Context, conn *grpc.ClientConn, p *pb.FileRequest, audience string) (*pb.FileResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Create an identity token.
+	// With a global TokenSource tokens would be reused and auto-refreshed at need.
+	// A given TokenSource is specific to the audience.
+	tokenSource, err := idtoken.NewTokenSource(ctx, audience)
+	if err != nil {
+		return nil, fmt.Errorf("idtoken.NewTokenSource: %v", err)
+	}
+	token, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("TokenSource.Token: %v", err)
+	}
+
+	// Add token to gRPC Request.
+	ctx = grpcMetadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token.AccessToken)
+
+	// Send the request.
+	client := pb.NewRVClient(conn)
+	return client.FileUpload(ctx, p)
+}
+
+func makeReq(path string) (*pb.FileRequest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.FileRequest{
+		Filename: path,
+		Content:  raw,
+		Md5Sum:   fmt.Sprintf("%x", md5.Sum(raw)),
+		Project:  pb.FileRequest_ROUTEVIEWS,
+	}, nil
+}
 
 func main() {
 	flag.Parse()
@@ -22,24 +90,19 @@ func main() {
 		log.Fatal("a filename to transfer is required for operation")
 	}
 
-	// Create the gRPC Connection.
-	var opts []grpc.DialOption
-	// TODO(morrowc): Fix the TLS process here, do not be insecure.
-	opts = append(opts, grpc.WithInsecure())
-	conn, err := grpc.Dial(*server, opts...)
+	conn, err := newConn(*server)
 	if err != nil {
 		log.Fatalf("fail to dial(%v): %v", *server, err)
 	}
 	defer conn.Close()
 	ctx := context.Background()
 
-	client := pb.NewRVClient(conn)
-
-	r := pb.FileRequest{
-		Filename: *file,
+	req, err := makeReq(*file)
+	if err != nil {
+		log.Fatalf("fail to makeReq(%v): %v", *file, err)
 	}
 
-	resp, err := client.FileUpload(ctx, &r)
+	resp, err := upload(ctx, conn, req, strings.Split(*server, ":")[0])
 	if err != nil {
 		log.Fatalf("failed to upload file(%v): %v", *file, err)
 	}

--- a/cmd/archive_upload_server/README.md
+++ b/cmd/archive_upload_server/README.md
@@ -19,7 +19,7 @@ Deployed to GCP CloudRun, from the project's Docker image store.
 
 3. Have cloud run, run the job:
   ```shell
-  $ gcloud run deploy  rv-server --image us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest
+  $ gcloud run deploy  rv-server --image us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest --use-http2 --no-allow-unauthenticated
   ```
 
 4. Verify the loadbalanced path is in place from internet -> port.

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	port   = os.Getenv("PORT")
-	bucket = flag.String("bucket", "routeviews-archive", "Cloud storage bucket name.")
+	bucket = flag.String("bucket", "routeviews-archives", "Cloud storage bucket name.")
 
 	// TODO(morrowc): find a method to define the TLS certificate to be used, if this will
 	//                not be done through GCLB's inbound https path.
@@ -51,6 +51,7 @@ type rvServer struct {
 func (r rvServer) fileStore(ctx context.Context, fn string, b []byte) error {
 	// Store the file content to the
 	wc := r.sc.Bucket(r.bucket).Object(fn).NewWriter(ctx)
+	defer wc.Close()
 	if _, err := io.Copy(wc, bytes.NewReader(b)); err != nil {
 		return fmt.Errorf("failed copying content to destination: %s/%s: %v", r.bucket, fn, err)
 	}


### PR DESCRIPTION
Add TLS and authentication to the Go gRPC client. The code is basically following examples at https://cloud.google.com/run/docs/triggering/grpc

Also fixed a few typos/bugs.