### PR TITLE
Extend the max message size, from default to 10mb.

### DIFF
--- a/cmd/archive_upload_client/client.go
+++ b/cmd/archive_upload_client/client.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	// Max message size set to 10mb.
-	// Max message size set to 10mb.
-	maxMsgSize = 10 * 1024 * 1024
+	// Max message size set to 50mb.
+	maxMsgSize = 50 * 1024 * 1024
 )
 
 var (

--- a/cmd/archive_upload_client/client.go
+++ b/cmd/archive_upload_client/client.go
@@ -22,6 +22,12 @@ import (
 	grpcMetadata "google.golang.org/grpc/metadata"
 )
 
+const (
+	// Max message size set to 10mb.
+	// Max message size set to 10mb.
+	maxMsgSize = 10 * 1024 * 1024
+)
+
 var (
 	server = flag.String("server", "localhost:9876", "The host:port of the gRPC server.")
 	file   = flag.String("file", "", "A local File to transfer to cloud storage.")
@@ -38,7 +44,12 @@ func newConn(host string) (*grpc.ClientConn, error) {
 	cred := credentials.NewTLS(&tls.Config{
 		RootCAs: systemRoots,
 	})
-	opts = append(opts, grpc.WithTransportCredentials(cred))
+	opts = append(opts,
+		[]grpc.DialOption{
+			grpc.WithTransportCredentials(cred),
+			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(maxMsgSize)),
+		}...,
+	)
 
 	return grpc.Dial(host, opts...)
 }

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -32,8 +32,8 @@ const (
 	// Be sure to have the JSON authentication bits in env(GOOGLE_APPLICATION_CREDENTIALS)
 	projectID = "1071922449970"
 
-	// Set a max receive message size: 10mb
-	maxMsgSize = 10 * 1024 * 1024
+	// Set a max receive message size: 50mb
+	maxMsgSize = 50 * 1024 * 1024
 )
 
 var (

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -126,8 +126,9 @@ func main() {
 
 	if port == "" {
 		port = "9876"
-		log.Infof("Default port selected: %s", port)
 	}
+	log.Infof("Service will listren on port : %s", port)
+
 	// Start the listener.
 	// NOTE: this listens on all IP Addresses, caution when testing.
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -31,6 +31,9 @@ const (
 	// TODO(morrowc): Sort out organization privilege problems to create a service account key.
 	// Be sure to have the JSON authentication bits in env(GOOGLE_APPLICATION_CREDENTIALS)
 	projectID = "1071922449970"
+
+	// Set a max receive message size: 10mb
+	maxMsgSize = 10 * 1024 * 1024
 )
 
 var (
@@ -143,7 +146,11 @@ func main() {
 		log.Fatalf("failed to create new rvServer: %v", err)
 	}
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(
+		grpc.MaxMsgSize(maxMsgSize),
+		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.MaxSendMsgSize(maxMsgSize),
+	)
 	pb.RegisterRVServer(s, r)
 
 	// Register the reflection service on gRPC server.


### PR DESCRIPTION
gRPC has a max message size of 4mb by default.
Extend that to avoid some of the larger update messages causing:
  ResourceExhausted desc = grpc: received message larger than max (4944783 vs. 4194304)