### PR TITLE
In case the credentials are 'user' and not 'service', attempt altpath.

### DIFF
--- a/cmd/archive_upload_client/client.go
+++ b/cmd/archive_upload_client/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/idtoken"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -62,8 +63,16 @@ func upload(ctx context.Context, conn *grpc.ClientConn, p *pb.FileRequest, audie
 	// A given TokenSource is specific to the audience.
 	tokenSource, err := idtoken.NewTokenSource(ctx, audience)
 	if err != nil {
-		return nil, fmt.Errorf("idtoken.NewTokenSource: %v", err)
+		if err.Error() != `idtoken: credential must be service_account, found "authorized_user"` {
+			return nil, fmt.Errorf("idtoken.NewTokenSource: %v", err)
+		}
+		gts, err := google.DefaultTokenSource(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("attempt to use Application Default Credentials failed: %v", err)
+		}
+		tokenSource = gts
 	}
+
 	token, err := tokenSource.Token()
 	if err != nil {
 		return nil, fmt.Errorf("TokenSource.Token: %v", err)


### PR DESCRIPTION
If the client credentials are 'authorized_user' credentials, attempt
to get credential/token with ApplicationDefaultCredentials.

