### PR TITLE
Authenticate gRPC requests with service account key

### DIFF
--- a/cmd/archive_upload_client/README.md
+++ b/cmd/archive_upload_client/README.md
@@ -1,0 +1,23 @@
+# RouteViews Archive Client
+
+gRPC client in Go to upload RouteViews archives.
+
+## Usage
+
+1. If you have already installed gcloud SDK ran `gcloud auth login` on the machine:
+  ```shell
+  $ go run client.go --file [filename] --server [host:port]
+  ```
+
+2. If you do not have gcloud SDK on the machine, download the service account key file and:
+  ```shell
+  $ go run client.go --file [filename] --server [host:port] --sa_key [path/to/key.json]
+  ```
+
+  Alternatively, you can point the environment variable "GOOGLE_APPLICATION_CREDENTIALS"
+  to the key file and then skip the "sa_key" flag:
+
+  ```shell
+  $ export GOOGLE_APPLICATION_CREDENTIALS=[path/to/key.json]
+  $ go run client.go --file [filename] --server [host:port]
+  ```


### PR DESCRIPTION
Originally I only allow authenticating by passing in key file explicitly; now I also incorporated Chris's approach of using GOOGLE_APPLICATION_CREDENTIALS. 