### PR TITLE
Set project type in metadata of uploaded objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,9 @@ require (
 	github.com/routeviews/google-cloud-storage/proto/rv v0.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/api v0.62.0
 	google.golang.org/grpc v1.40.1
 	google.golang.org/protobuf v1.27.1
 )


### PR DESCRIPTION
The gRPC server will set the project type (routeviews, RIPE, ...) in the metadata when it writes to GCS; the converter will extract collector name based on the project type in metadata and the object path.

Right now, if the project type is not supported/recognized, the collector field will be left empty.