### PR TITLE
Issue18 - Increase the max message size from 50mB to 512mB. 

### DIFF
--- a/cmd/archive_upload_client/client.go
+++ b/cmd/archive_upload_client/client.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Max message size set to 50mb.
-	maxMsgSize = 50 * 1024 * 1024
+	maxMsgSize = 512 * 1024 * 1024
 )
 
 var (

--- a/cmd/archive_upload_mass_upload/mass_upload.go
+++ b/cmd/archive_upload_mass_upload/mass_upload.go
@@ -40,6 +40,8 @@ const (
 	maxMsgSize = 50 * 1024 * 1024
 	// Max ftp errors before exiting the process.
 	maxFTPErrs = 50
+	// Channel buffer size for the Walk() function to fill.
+	maxWalk = 5000
 )
 
 var (
@@ -165,7 +167,7 @@ func new(ctx context.Context, aUser, aPasswd, site, bucket, grpcService, saKey s
 		bh:      bh,
 		fc:      f,
 		bucket:  bucket,
-		ch:      make(chan *evalFile),
+		ch:      make(chan *evalFile, maxWalk),
 		metrics: map[string]int{"sync": 0, "skip": 0, "error": 0},
 	}, nil
 }

--- a/cmd/archive_upload_mass_upload/mass_upload.go
+++ b/cmd/archive_upload_mass_upload/mass_upload.go
@@ -37,7 +37,7 @@ import (
 const (
 	dialTimeout = 5 * time.Second
 	// Max message size set to 50mb.
-	maxMsgSize = 50 * 1024 * 1024
+	maxMsgSize = 512 * 1024 * 1024
 	// Max ftp errors before exiting the process.
 	maxFTPErrs = 50
 	// Channel buffer size for the Walk() function to fill.

--- a/cmd/archive_upload_mass_upload/mass_upload.go
+++ b/cmd/archive_upload_mass_upload/mass_upload.go
@@ -355,7 +355,6 @@ func main() {
 
 	// Start the FTP walk, then read from the channel and evaluate each file.
 	go c.ftpWalk(dir)
-	// c.readChannel(ctx)
 
 	// Wait on all readChannel routines to finish.
 	c.wg.Wait()

--- a/cmd/archive_upload_server/README.md
+++ b/cmd/archive_upload_server/README.md
@@ -21,7 +21,8 @@ Deployed to GCP CloudRun, from the project's Docker image store.
   ```shell
   $ gcloud run deploy  rv-server \
             --image us-docker.pkg.dev/public-routing-data-backup/cloudrun/rv-server:latest \
-            --use-http2 --no-allow-unauthenticated
+            --use-http2 --no-allow-unauthenticated \
+            --memory 1G
   ```
 
 4. Reserve an IPv4/6 address for the load balancer (DO THIS ONCE)

--- a/cmd/archive_upload_server/server.go
+++ b/cmd/archive_upload_server/server.go
@@ -34,7 +34,7 @@ const (
 	projectID = "1071922449970"
 
 	// Set a max receive message size: 50mb
-	maxMsgSize = 50 * 1024 * 1024
+	maxMsgSize = 512 * 1024 * 1024
 )
 
 var (


### PR DESCRIPTION
There are a few outsized files in the archive, specifically:

```shell  
  241060964 Jan 20 11:45 updates.20220120.1130.bz2
```

So, increase the max message size to accommodate. There's the clear trend here to: "Heck, just set this to 2GB and stop twiddling up a bit every failure..." - Happy to change the proposed 512 to <something else>.

Also, apparently my git history had changes including:

 - adding a new ftp client to the readChannel function
 - making the evalFile channel buffered

Adding the FTP connection was done to address failures during Walk() with concurrent list/retrieve functions. Looking at tcpdump, it appears that the ftp server/client expect a single serial process to progress. There appears to be a limit to the number of data ports the server will allocate per client command connection, that limit is one. If the client asks for more than one data channel, previous data channels are closed causing interruptions or breakage in the upload processing.
