### PR TITLE
A tool to transfer archives to bigquery in small load jobs

### DIFF
--- a/cmd/convert_all/README.md
+++ b/cmd/convert_all/README.md
@@ -1,6 +1,6 @@
 # Convert all archives
 
-A CLI tool to convert all archives from src bucket/directory to the dst bucket. It will send conversion requests to the cloud run endpoint in a controlled manner, and it will stop at the first failed conversion.
+A CLI tool to convert all archives from src bucket/directory to the dst bucket. It will send conversion requests to the cloud run endpoint in a controlled manner. It will try any conversion requests at most three times (with 30s backoff after each failed attempt).
 
 ## Usage
   ```shell

--- a/cmd/transfer_all/README.md
+++ b/cmd/transfer_all/README.md
@@ -1,0 +1,14 @@
+# transfer_all: Transfer all JSON BGP updates to bigquery.
+
+Transfer routing data archives (in JSON format) to BigQuery. As Bigquery has
+a 10,000 files limit on each load job, this tool will create a load config for
+each month & collector which automatically reloads at midnight.
+
+## Usage
+  ```shell
+  $  go run cmd/transfer_all/main.go --project=public-routing-data-archive \
+                                     --location=US \
+                                     --bucket=routeviews-bigquery \
+                                     --dataset=public_routing_data \
+                                     --table=updates
+  ```

--- a/cmd/transfer_all/main.go
+++ b/cmd/transfer_all/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"flag"
+
+	datatransfer "cloud.google.com/go/bigquery/datatransfer/apiv1"
+	"cloud.google.com/go/storage"
+	"github.com/golang/glog"
+
+	bqtransfer "github.com/routeviews/google-cloud-storage/pkg/bq_transfer"
+)
+
+var (
+	project  = flag.String("project", "public-routing-data-backup", "Project that contains public routing data.")
+	location = flag.String("location", "US", "Location of the bigquery dataset.")
+	dataset  = flag.String("dataset", "historical_routing_data", "Dataset that stores all routing updates.")
+	table    = flag.String("table", "updates", "Table that stores all routing updates.")
+	bucket   = flag.String("bucket", "routeviews-bigquery", "GCS bucket that saves all MRT archives.")
+)
+
+func main() {
+	flag.Parse()
+
+	ctx := context.Background()
+
+	sc, err := storage.NewClient(ctx)
+	if err != nil {
+		glog.Exit(err)
+	}
+	defer sc.Close()
+
+	dc, err := datatransfer.NewClient(ctx)
+	if err != nil {
+		glog.Exit(err)
+	}
+	defer dc.Close()
+
+	if err := bqtransfer.Transfer(ctx, sc, dc, &bqtransfer.TransferParams{
+		Project:  *project,
+		Location: *location,
+		Dataset:  *dataset,
+		Table:    *table,
+		Bucket:   *bucket,
+	}); err != nil {
+		glog.Exit(err)
+	}
+
+	// TODO: update current month of transfer to every 15 minutes.
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go/bigquery v1.8.0
 	cloud.google.com/go/storage v1.18.2
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/dsnet/compress v0.0.1
 	github.com/fsouza/fake-gcs-server v1.31.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -534,7 +536,6 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/bq_transfer/bq_transfer.go
+++ b/pkg/bq_transfer/bq_transfer.go
@@ -1,0 +1,158 @@
+// Package bqtransfer provides utilities to transfer large amound of converted
+// routing archives to BigQuery using Data Transfer Service.
+package bqtransfer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/cenkalti/backoff"
+	"github.com/golang/glog"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	datatransfer "cloud.google.com/go/bigquery/datatransfer/apiv1"
+	dpb "google.golang.org/genproto/googleapis/cloud/bigquery/datatransfer/v1"
+)
+
+var queryInterval = time.Second
+
+type TransferParams struct {
+	Project  string
+	Location string
+	Dataset  string
+	Table    string
+	Bucket   string
+}
+
+// fetchMonthDirs traverse all directories and finds the month directories (i.e.
+// the directories ended with YYYY.MM only contain a month of data.)
+func fetchMonthDirs(ctx context.Context, cli *storage.Client, bkt string) ([]string, error) {
+	queries := []*storage.Query{{Delimiter: "/"}}
+	var res []string
+	for len(queries) > 0 {
+		query := queries[0]
+		queries = queries[1:]
+		it := cli.Bucket(bkt).Objects(ctx, query)
+
+		for {
+			attrs, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			dirs := strings.Split(attrs.Prefix, "/")
+			// Minus 2 because the last character of the path is a slash and
+			// thus the last element will be "".
+			if len(dirs) < 2 {
+				fmt.Println(query.Prefix, attrs.Prefix)
+				glog.Errorf("prefix shorter than 2 levels: %s", attrs.Prefix)
+				continue
+			}
+			parent := dirs[len(dirs)-2]
+			// Check if the value is in a YYYY.MM format.
+			if _, err := time.Parse("2006.01", parent); err == nil {
+				res = append(res, attrs.Prefix)
+			} else if attrs.Prefix != "" {
+				queries = append(queries, &storage.Query{Prefix: attrs.Prefix, Delimiter: "/"})
+			}
+		}
+	}
+	return res, nil
+}
+
+// fetchCoveredDirs finds the GCS prefixes that are already covered.
+func fetchCoveredDirs(ctx context.Context, cli *datatransfer.Client, project string) (map[string]string, error) {
+	req := &dpb.ListTransferConfigsRequest{
+		Parent: fmt.Sprintf("projects/%s", project),
+	}
+	res := make(map[string]string)
+	it := cli.ListTransferConfigs(ctx, req)
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		res[resp.GetParams().GetFields()["data_path_template"].GetStringValue()] = resp.GetName()
+	}
+
+	return res, nil
+}
+
+func makeTransferConfig(cfg *TransferParams, dir, pattern string) *dpb.TransferConfig {
+	return &dpb.TransferConfig{
+		DisplayName:  dir,
+		DataSourceId: "google_cloud_storage",
+		Destination: &dpb.TransferConfig_DestinationDatasetId{
+			DestinationDatasetId: cfg.Dataset,
+		},
+		Schedule: "every day 00:00",
+		EmailPreferences: &dpb.EmailPreferences{
+			// TODO: flip this to true when transfers stablize.
+			EnableFailureEmail: false,
+		},
+		Params: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"destination_table_name_template": structpb.NewStringValue(cfg.Table),
+				"data_path_template":              structpb.NewStringValue(pattern),
+				"file_format":                     structpb.NewStringValue("JSON"),
+				"max_bad_records":                 structpb.NewStringValue("0"),
+				"skip_leading_rows":               structpb.NewStringValue("0"),
+				"write_disposition":               structpb.NewStringValue("APPEND"),
+			},
+		},
+	}
+}
+
+func createTransferRuns(ctx context.Context, cli *datatransfer.Client, dirs []string, covered map[string]string, cfg *TransferParams) error {
+	for i, dir := range dirs {
+		pattern := fmt.Sprintf("gs://%s/%s*/*.gz", cfg.Bucket, dir)
+		if cid, ok := covered[pattern]; ok {
+			glog.Warningf("Skipped: config %s is covering %s", cid, pattern)
+			continue
+		}
+		// Create a new transfer config if not found.
+		err := backoff.Retry(func() error {
+			resp, err := cli.CreateTransferConfig(ctx, &dpb.CreateTransferConfigRequest{
+				Parent:         fmt.Sprintf("projects/%s/locations/%s", cfg.Project, cfg.Location),
+				TransferConfig: makeTransferConfig(cfg, dir, pattern),
+			})
+			if err != nil {
+				glog.Warningf("attempt to transfer %s failed: %v", pattern, err)
+				return err
+			}
+			glog.Infof("%d/%d: Created transfer config %s for %s\n", i+1, len(dirs), resp.Name, pattern)
+			return nil
+		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 3))
+		if err != nil {
+			return err
+		}
+
+		// Avoid exceeding DTS API access quota.
+		time.Sleep(queryInterval)
+	}
+	return nil
+}
+
+// Transfer transfers all archives from a bucket to a BigQuery table.
+func Transfer(ctx context.Context, sc *storage.Client, dc *datatransfer.Client, params *TransferParams) error {
+	monthPrefixes, err := fetchMonthDirs(ctx, sc, params.Bucket)
+	if err != nil {
+		return fmt.Errorf("fetchMonthDirs(%s): %v", params.Bucket, err)
+	}
+
+	covered, err := fetchCoveredDirs(ctx, dc, params.Project)
+	if err != nil {
+		return fmt.Errorf("fetchCoveredDirs(%s): %v", params.Project, err)
+	}
+
+	return createTransferRuns(ctx, dc, monthPrefixes, covered, params)
+}


### PR DESCRIPTION
This tool can potentially be invoked by Cloud Scheduler to check and generate new transfer runs (if needed).

Also added a small retry mechanism to cope with Cloud Run's rate limter.