### PR TITLE
Fix python-client GH Action, was missing 'package' step

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -4,16 +4,12 @@ env:
 
 on: 
   push: 
-    paths-ignore:
-      - '.vscode/**'
     paths: 
       - 'python-client/**'
       - '.github/workflows/python-client.yml'
     branches:
       - main
   pull_request: 
-    paths-ignore:
-      - '.vscode/**'
     paths: 
       - 'python-client/**'
       - '.github/workflows/python-client.yml'

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -36,14 +36,19 @@ jobs:
         run: |
           pip install -e $WORKDIR
 
-      - name: Test Annotate Plugin
+      - name: Install Annotate Test Results Plugin
         run: pip install pytest-github-actions-annotate-failures
 
       - name: Test
         run: |
           pytest $WORKDIR
+      
+      - name: Package 📦
+        if: github.ref == 'refs/heads/main'
+        run: |
+          python setup.py sdist
         
-      - name: Publish distribution 📦 to PyPI
+      - name: Publish 📦 to PyPI
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -5,13 +5,19 @@ env:
 
 on: 
   push: 
+    paths-ignore:
+      - '.vscode/**'
     paths: 
       - 'python-client/**'
+      - '.github/workflows/python-client.yml'
     branches:
       - main
   pull_request: 
+    paths-ignore:
+      - '.vscode/**'
     paths: 
       - 'python-client/**'
+      - '.github/workflows/python-client.yml'
 
 jobs:
   test-and-deploy:

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -1,4 +1,3 @@
-# .github/workflows/python-client.yml
 name: python-client
 env:
   WORKDIR: python-client

--- a/.github/workflows/rv.yml
+++ b/.github/workflows/rv.yml
@@ -2,13 +2,15 @@ name: RV
 on: 
   push: 
     paths-ignore:
+      - '.vscode/**'
       - 'python-client/**'
       - '.github/workflows/python-client.yml'
   pull_request:
     paths-ignore:
+      - '.vscode/**'
       - 'python-client/**'
       - '.github/workflows/python-client.yml'
-  
+
 jobs:
 
   build:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,14 @@
         "bgpdata",
         "CICD",
         "grpcio",
+        "NTSJENKINS",
         "protobuf",
+        "pypa",
+        "pypi",
         "routeviews",
-        "uologging"
+        "sdist",
+        "uologging",
+        "WORKDIR"
     ],
     "files.exclude": {
         "**/__pycache__": true,


### PR DESCRIPTION
Fix: Cannot publish the 'dist' directory if it hasn't been created.

I forgot to actually build the python source distribution. So, prior PR failed to deploy since there was no 'dist'  directory to deploy!