### PR TITLE
(Try to) fix packages_dir for deploying to PyPI.

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -53,7 +53,7 @@ jobs:
         
       - name: Publish 📦 to PyPI
         if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           password: ${{ secrets.NTSJENKINS_PYPI }}
-          packages_dir: dist
+          packages_dir: python-client/dist


### PR DESCRIPTION
From build fail logs, it looks like this version of gh-action-pypi-publish does not know about "working-directory"

Pinned the version of that GH-Action so that if this is someday fixed, then we won't start seeing build failures.