### PR TITLE
Fix python-client deployment (provide '__token__' user)

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -55,5 +55,6 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
+          user: __token__
           password: ${{ secrets.NTSJENKINS_PYPI }}
           packages_dir: python-client/dist


### PR DESCRIPTION
Most examples online do have 'user: __token__', so maybe that'll fix our most recent deployment failure...?