### PR TITLE
Cloud cron job to create BQ transfer configs and set up recurrent transfers

### DIFF
--- a/cmd/archive_upload_server/Dockerfile
+++ b/cmd/archive_upload_server/Dockerfile
@@ -23,4 +23,4 @@ RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -
 # Copy the built binary into the docker image.
 COPY --from=builder /app/server /app/server
 
-CMD ["/app/server"]
+CMD ["/app/server", "--logtostderr=1"]

--- a/cmd/converter/main.go
+++ b/cmd/converter/main.go
@@ -103,6 +103,7 @@ func main() {
 	if *isDebug {
 		log.SetLevel(log.DebugLevel)
 	}
+	log.SetFormatter(&log.JSONFormatter{})
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/cmd/utils/transfer_all/Dockerfile
+++ b/cmd/utils/transfer_all/Dockerfile
@@ -1,0 +1,19 @@
+# Should be run from the parent directory, e.g. docker build -f cmd/converter/Dockerfile . -t [IMAGE_URL]
+FROM golang:1.17-buster as builder
+ 
+WORKDIR /app
+ 
+COPY . ./
+
+RUN go mod download
+ 
+RUN go build -v -o transfer_all cmd/utils/transfer_all/main.go
+ 
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/transfer_all /app/transfer_all
+
+CMD ["/app/transfer_all", "--logtostderr=1"]

--- a/cmd/utils/transfer_all/README.md
+++ b/cmd/utils/transfer_all/README.md
@@ -4,11 +4,38 @@ Transfer routing data archives (in JSON format) to BigQuery. As Bigquery has
 a 10,000 files limit on each load job, this tool will create a load config for
 each month & collector which automatically reloads at midnight.
 
-## Usage
+## Usage (local)
   ```shell
   $  go run cmd/utils/transfer_all/main.go --project=public-routing-data-archive \
                                      --location=US \
                                      --bucket=routeviews-bigquery \
                                      --dataset=public_routing_data \
-                                     --table=updates
+                                     --table=updates &
+
+  $  curl localhost:8080 # trigger transfer
   ```
+
+### Deploy to Cloud Run
+
+1.  Build the image from the root directory. 
+    -   In root directory, 
+    ```shell
+    $   docker build -f cmd/utils/transfer_all/Dockerfile . -t us-docker.pkg.dev/public-routing-data-backup/cloudrun/transfer-all:latest
+    ```
+    -   Don't forget to upload it to the registries: 
+    ```shell
+    docker push \
+        us-docker.pkg.dev/public-routing-data-backup/cloudrun/transfer-all:latest
+    ```
+2.  Deploy the image:
+    -   Example:
+    ```shell
+    $   gcloud run deploy transfer-all \
+        --image us-docker.pkg.dev/public-routing-data-backup/cloudrun/transfer-all:latest \
+        --concurrency=1 --max-instances=2 \
+        --no-allow-unauthenticated \
+        --timeout=3600
+    ```
+3.  **[Only need once]** Use Cloud Scheduler to trigger the cloud run service every hour.
+    - Remember to add approriate permissions to the caller.
+    - The serivce/personal account that runs this server must have roles `BigQuery Data Viewer`, `BigQuery Data Editor` and `Bigquery Job User`.

--- a/pkg/bq_transfer/bq_transfer.go
+++ b/pkg/bq_transfer/bq_transfer.go
@@ -113,7 +113,7 @@ func makeTransferConfig(cfg *TransferParams, dir, pattern string) *dpb.TransferC
 }
 
 func createTransferRuns(ctx context.Context, cli *datatransfer.Client, dirs []string, covered map[string]string, cfg *TransferParams) error {
-	for i, dir := range dirs {
+	for _, dir := range dirs {
 		pattern := fmt.Sprintf("gs://%s/%s*/*.gz", cfg.Bucket, dir)
 		if cid, ok := covered[pattern]; ok {
 			glog.Warningf("Skipped: config %s is covering %s", cid, pattern)
@@ -129,7 +129,7 @@ func createTransferRuns(ctx context.Context, cli *datatransfer.Client, dirs []st
 				glog.Warningf("attempt to transfer %s failed: %v", pattern, err)
 				return err
 			}
-			glog.Infof("%d/%d: Created transfer config %s for %s\n", i+1, len(dirs), resp.Name, pattern)
+			glog.Infof("Created transfer config %s for %s\n", resp.Name, pattern)
 			return nil
 		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 3))
 		if err != nil {
@@ -153,6 +153,7 @@ func Transfer(ctx context.Context, sc *storage.Client, dc *datatransfer.Client, 
 	if err != nil {
 		return fmt.Errorf("fetchCoveredDirs(%s): %v", params.Project, err)
 	}
+	glog.Infof("Found %d month dirs, %d covered dirs", len(monthPrefixes), len(covered))
 
 	return createTransferRuns(ctx, dc, monthPrefixes, covered, params)
 }


### PR DESCRIPTION
This PR contains a HTTP server to be deployed to Cloud Run. The pipline:

1. Deploy this server on Cloud Run;
2. Setup a cron job in Cloud Scheduler (currently we have one running every hour);
2. Hook up the cron job with the Cloud Run.

Now every hour, this service will look at if there are any new **month** directories and create recurrent transfer runs for those directories. 