### PR TITLE
Issue 40: Update python and golang versions.

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.10"
 
       - name: Install pinned dependencies
         run: |

--- a/.github/workflows/rv.yml
+++ b/.github/workflows/rv.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: '1.20'
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
The python action is reporting an error:
  Error: Version 3.6 with arch x64 not found

golang version 20 is more modern, verison 16 is old-n-busted (not quite!)