### PR TITLE
python-client workflow updates

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: 'pip'
 
       - name: Install pinned dependencies
         run: |

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          cache: 'pip'
 
       - name: Install pinned dependencies
         run: |

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Setup Python (faster than using Python container)
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: python-client
 
     steps:
-      - name: Checkout repo
+      - name: Checkout source code
         uses: actions/checkout@v4
 
       # Setup Python (faster than using Python container)
@@ -40,7 +40,7 @@ jobs:
         run: |
           pip install -e .
 
-      - name: Install Annotate Test Results Plugin
+      - name: Install plugin that annotates test results 
         run: pip install pytest-github-actions-annotate-failures
 
       - name: Test

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -51,11 +51,15 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           python setup.py sdist
-        
-      - name: Publish 📦 to PyPI
-        if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@release/v1.5
-        with:
-          user: __token__
-          password: ${{ secrets.NTSJENKINS_PYPI }}
-          packages_dir: python-client/dist
+
+# This job requires access to the UO NTS Jenkins server.
+# If we want to publish to pypi, we'll need to find an
+# alternate build server.
+#
+#      - name: Publish 📦 to PyPI
+#        if: github.ref == 'refs/heads/main'
+#        uses: pypa/gh-action-pypi-publish@release/v1.5
+#        with:
+#          user: __token__
+#          password: ${{ secrets.NTSJENKINS_PYPI }}
+#          packages_dir: python-client/dist


### PR DESCRIPTION
Two changes here:

 1.  update GH action versions to something current
- setup-python
- checkout
2. disable the job that publishes to pypi as it depends on a resource we don't control