### PR TITLE
Update pytest version

### DIFF
--- a/python-client/requirements.txt
+++ b/python-client/requirements.txt
@@ -12,7 +12,6 @@ iniconfig==1.1.1
 packaging==21.3
 pluggy==1.0.0
 protobuf==3.18.3
-py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.7

--- a/python-client/requirements.txt
+++ b/python-client/requirements.txt
@@ -16,7 +16,7 @@ py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.7
-pytest==6.2.5
+pytest==7.2.0
 requests==2.31.0
 rsa==4.8
 six==1.15.0


### PR DESCRIPTION
Dependabot flagged a vuln in the 'py' dependency. The recommended fix is to upgrade 'pytest' to 7.2.0 which removed 'py' from the dependencies.

This PR does the following:
- update pytest version to 7.2.0
- delete 'py' from requirements.txt