### PR TITLE
Handle non-update BGP4MP messages without panic

### DIFF
--- a/pkg/mrt_converter/mrt_converter.go
+++ b/pkg/mrt_converter/mrt_converter.go
@@ -156,8 +156,16 @@ func parseUpdate(collector string, h *mrt.MRTHeader, buf []byte) (*update, error
 		return nil, fmt.Errorf("failed to parse body: %v", err)
 	}
 
-	mrtMsg := msg.Body.(*mrt.BGP4MPMessage)
-	bgpUpdate := mrtMsg.BGPMessage.Body.(*bgp.BGPUpdate)
+	mrtMsg, ok := msg.Body.(*mrt.BGP4MPMessage)
+	if !ok {
+		return nil, fmt.Errorf("unexpected MRT body type %T", msg.Body)
+	}
+
+	bgpUpdate, ok := mrtMsg.BGPMessage.Body.(*bgp.BGPUpdate)
+	if !ok {
+		return nil, fmt.Errorf("unexpected BGP message body type %T", mrtMsg.BGPMessage.Body)
+	}
+
 	return &update{
 		SeenAt:     h.GetTime(),
 		PeerAS:     mrtMsg.PeerAS,

--- a/pkg/mrt_converter/mrt_converter_test.go
+++ b/pkg/mrt_converter/mrt_converter_test.go
@@ -37,6 +37,12 @@ var (
 		bgp.NewIPAddrPrefix(24, "30.0.0.0"),
 		bgp.NewIPAddrPrefix(24, "40.0.0.0"),
 	}))
+	fakeAS4Keepalive = mrt.NewBGP4MPMessage(
+		100000, 6447, 0,
+		"1.0.0.0", "2.0.0.0",
+		true,
+		bgp.NewBGPKeepAliveMessage(),
+	)
 	fakeAS4Withdrawal = mrt.NewBGP4MPMessage(100000, 6447, 0, "1.0.0.0", "2.0.0.0", true, bgp.NewBGPUpdateMessage([]*bgp.IPAddrPrefix{
 		bgp.NewIPAddrPrefix(24, "30.0.0.0"),
 		bgp.NewIPAddrPrefix(24, "40.0.0.0"),
@@ -214,6 +220,19 @@ func TestParseUpdate(t *testing.T) {
 			collector: "route-views3",
 			body:      encodeBGP4MP(t, fakeAS4Ann),
 			wantErr:   true,
+		},
+		{
+			desc:      "BGP4MP message containing non-update BGP message",
+			collector: "route-views3",
+			header: fakeMRTHeader(
+				t,
+				fakeTime,
+				mrt.BGP4MP,
+				mrt.MESSAGE_AS4,
+				len(encodeBGP4MP(t, fakeAS4Keepalive)),
+			),
+			body:    encodeBGP4MP(t, fakeAS4Keepalive),
+			wantErr: true,
 		},
 	}
 
@@ -420,6 +439,24 @@ func TestConvertMRT(t *testing.T) {
 				0, 23, 2, 100, 0, 0, 0}, // Wrong withdrawn routes length (100).
 				encodeMRTMessage(t, fakeMRTMessage(t, fakeTime, mrt.BGP4MP, mrt.MESSAGE_AS4, fakeAS4Withdrawal))),
 
+			want: []*update{{
+				Collector:  "route-views3",
+				SeenAt:     unextended,
+				PeerAS:     100000,
+				Withdrawn:  []string{"30.0.0.0/24", "40.0.0.0/24"},
+				Attributes: nil,
+			}},
+		}, {
+			desc:      "skip non-update BGP message and continue conversion",
+			collector: "route-views3",
+			archive: concatMsgs(
+				encodeMRTMessage(t, fakeMRTMessage(
+					t, fakeTime, mrt.BGP4MP, mrt.MESSAGE_AS4, fakeAS4Keepalive,
+				)),
+				encodeMRTMessage(t, fakeMRTMessage(
+					t, fakeTime, mrt.BGP4MP, mrt.MESSAGE_AS4, fakeAS4Withdrawal,
+				)),
+			),
 			want: []*update{{
 				Collector:  "route-views3",
 				SeenAt:     unextended,


### PR DESCRIPTION
`parseUpdate` assumes that every parsed BGP4MP message contains a BGP UPDATE and uses unchecked type assertions. A valid BGP4MP message carrying another BGP message type, such as KEEPALIVE, therefore causes the converter to panic.

This change replaces the unchecked assertions with type checks that return errors through the existing best-effort conversion path. Non-update messages are skipped, allowing conversion to continue with subsequent updates.

Tests cover both the direct parsing case and conversion of a stream containing a KEEPALIVE followed by a valid BGP UPDATE carrying withdrawals.

Testing: `pkg/mrt_converter` passes locally. Full repository testing is currently affected by pre-existing Go module dependency drift, so no dependency changes are included in this PR.